### PR TITLE
feat: Analytics 90d and sort search by download counts

### DIFF
--- a/internal/models/formula.go
+++ b/internal/models/formula.go
@@ -50,6 +50,24 @@ type Formula struct {
 	TapGitHead             string             `json:"tap_git_head"`
 	RubySourcePath         string             `json:"ruby_source_path"`
 	RubySourceChecksum     RubySourceChecksum `json:"ruby_source_checksum"`
+	Analytics90dRank       int
+	Analytics90dDownloads  int
+}
+
+type Analytics struct {
+	Category   string          `json:"category"`
+	TotalItems int             `json:"total_items"`
+	StartDate  interface{}     `json:"start_date"`
+	EndDate    interface{}     `json:"end_date"`
+	TotalCount int             `json:"total_count"`
+	Items      []AnalyticsItem `json:"items"`
+}
+
+type AnalyticsItem struct {
+	Number  int    `json:"number"`
+	Formula string `json:"formula"`
+	Count   string `json:"count"`
+	Percent string `json:"percent"`
 }
 
 type Versions struct {


### PR DESCRIPTION
First, this is an excellent homebrew TUI tool! Thanks you!

I was looking for a way to browse Homebrew packages by "popularity". This PR adds a new column for Download counts, and also sorts search results by download count.

![CleanShot 2025-03-02 at 11 27 38](https://github.com/user-attachments/assets/3f759096-9293-4af0-92e3-e5cadc11682b)
