### PR TITLE
feat: Improvements to package filtering and locally installed packages

### DIFF
--- a/internal/models/formula.go
+++ b/internal/models/formula.go
@@ -52,6 +52,7 @@ type Formula struct {
 	RubySourceChecksum     RubySourceChecksum `json:"ruby_source_checksum"`
 	Analytics90dRank       int
 	Analytics90dDownloads  int
+	LocallyInstalled       bool `json:"-"`
 }
 
 type Analytics struct {

--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -113,13 +113,12 @@ func (s *AppService) search(searchText string, scrollToTop bool) {
 	}
 
 	if s.showOnlyOutdated {
-		tempList := &[]models.Formula{}
-		for _, info := range *sourceList {
+		sourceList = &[]models.Formula{}
+		for _, info := range *s.packages {
 			if info.Outdated {
-				*tempList = append(*tempList, info)
+				*sourceList = append(*sourceList, info)
 			}
 		}
-		sourceList = tempList
 	}
 
 	if searchText == "" {
@@ -237,13 +236,20 @@ func (s *AppService) getPackageInstallationDetails(info *models.Formula) string 
 		installedOnRequest = "Yes"
 	}
 
+	installedAsDependency := "No"
+	if info.Installed[0].InstalledAsDependency {
+		installedAsDependency = "Yes"
+	}
+
 	return fmt.Sprintf(
 		"[yellow::b]Installation Details[-]\n"+
 			"[blue]• Path:[-] %s\n"+
 			"[blue]• Installed on request:[-] %s\n"+
+			"[blue]• Installed as dependency:[-] %s\n"+
 			"[blue]• Installed version:[-] %s",
 		packagePrefix,
 		installedOnRequest,
+		installedAsDependency,
 		info.Installed[0].Version,
 	)
 }

--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -106,7 +106,7 @@ func (s *AppService) search(searchText string, scrollToTop bool) {
 	if s.showOnlyInstalled && !s.showOnlyOutdated {
 		sourceList = &[]models.Formula{}
 		for _, info := range *s.packages {
-			if len(info.Installed) > 0 && info.Installed[0].InstalledOnRequest {
+			if info.LocallyInstalled {
 				*sourceList = append(*sourceList, info)
 			}
 		}

--- a/internal/services/brew.go
+++ b/internal/services/brew.go
@@ -112,6 +112,11 @@ func (s *BrewService) loadInstalled() (err error) {
 		return err
 	}
 
+	// Mark all installed packages as locally installed
+	for i := range *s.installed {
+		(*s.installed)[i].LocallyInstalled = true
+	}
+
 	return nil
 }
 

--- a/internal/services/io.go
+++ b/internal/services/io.go
@@ -49,7 +49,14 @@ func (s *AppService) handleQuitEvent() {
 }
 
 func (s *AppService) handleFilterPackagesEvent() {
-	s.showOnlyInstalled = !s.showOnlyInstalled
+	if s.showOnlyOutdated {
+		s.showOnlyOutdated = false
+		s.showOnlyInstalled = true
+	} else {
+		s.showOnlyInstalled = !s.showOnlyInstalled
+	}
+
+	// Update the search field label
 	if s.showOnlyOutdated {
 		s.layout.GetSearch().Field().SetLabel("Search (Outdated): ")
 	} else if s.showOnlyInstalled {
@@ -62,7 +69,14 @@ func (s *AppService) handleFilterPackagesEvent() {
 }
 
 func (s *AppService) handleFilterOutdatedPackagesEvent() {
-	s.showOnlyOutdated = !s.showOnlyOutdated
+	if s.showOnlyInstalled {
+		s.showOnlyInstalled = false
+		s.showOnlyOutdated = true
+	} else {
+		s.showOnlyOutdated = !s.showOnlyOutdated
+	}
+
+	// Update the search field label
 	if s.showOnlyOutdated {
 		s.layout.GetSearch().Field().SetLabel("Search (Outdated): ")
 	} else if s.showOnlyInstalled {


### PR DESCRIPTION
Related issue: #10 

This pull request introduces enhancements to package filtering and installation tracking in the application. The most significant changes include adding a `LocallyInstalled` flag to track locally installed packages, improving filtering logic for installed and outdated packages, and including additional installation details in the UI.

### Enhancements to package filtering:

* [`internal/services/io.go`](diffhunk://#diff-99231f99686d99407561632b52e13318cab7352b1b2b7178d52ed956e399496cR52-R59): Updated `handleFilterPackagesEvent` and `handleFilterOutdatedPackagesEvent` to toggle between filtering installed and outdated packages more intuitively, ensuring only one filter is active at a time. Also added logic to update the search field label dynamically based on the active filter. [[1]](diffhunk://#diff-99231f99686d99407561632b52e13318cab7352b1b2b7178d52ed956e399496cR52-R59) [[2]](diffhunk://#diff-99231f99686d99407561632b52e13318cab7352b1b2b7178d52ed956e399496cR72-R79)

### Tracking locally installed packages:

* [`internal/models/formula.go`](diffhunk://#diff-99e2862153035d4da71b4eab215c1b1f7652e6e1a1690dbb47b0a7797d9b46f1R55): Added a `LocallyInstalled` boolean field to the `Formula` struct to identify packages installed locally.
* [`internal/services/brew.go`](diffhunk://#diff-325e1aaeb1b7863a9a86a14e08428e207edf680ddd884fc2f96d813c73bddccfR115-R119): Modified `loadInstalled` to mark all installed packages as locally installed by setting the `LocallyInstalled` flag to `true`.

### Improvements to installation details:

* [`internal/services/app.go`](diffhunk://#diff-d3e256eaf3144e3aa366f0f2bfa0cb8ccc8edc31e98bd8a5800eb6ce00029c37R239-R252): Enhanced `getPackageInstallationDetails` to display whether a package was installed as a dependency in addition to existing installation details.

### Optimization of filtering logic:

* [`internal/services/app.go`](diffhunk://#diff-d3e256eaf3144e3aa366f0f2bfa0cb8ccc8edc31e98bd8a5800eb6ce00029c37L109-L122): Simplified filtering logic in the `search` method by using the `LocallyInstalled` flag instead of checking installation details directly, and streamlined outdated package filtering. 