### PR TITLE
feat(12): cache formulajson

### DIFF
--- a/internal/services/command.go
+++ b/internal/services/command.go
@@ -14,7 +14,6 @@ type CommandServiceInterface interface {
 	UpdatePackage(info models.Formula, app *tview.Application, outputView *tview.TextView) error
 	RemovePackage(info models.Formula, app *tview.Application, outputView *tview.TextView) error
 	InstallPackage(info models.Formula, app *tview.Application, outputView *tview.TextView) error
-	UpdateHomebrew() error
 }
 
 type CommandService struct{}
@@ -41,14 +40,6 @@ func (s *CommandService) RemovePackage(info models.Formula, app *tview.Applicati
 func (s *CommandService) InstallPackage(info models.Formula, app *tview.Application, outputView *tview.TextView) error {
 	cmd := exec.Command("brew", "install", info.Name) // #nosec G204
 	return s.executeCommand(app, cmd, outputView)
-}
-
-func (s *CommandService) UpdateHomebrew() error {
-	cmd := exec.Command("brew", "update")
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (s *CommandService) executeCommand(


### PR DESCRIPTION
Related Issue: #12 

This pull request refactors and improves the `BrewService` and `AppService` in the codebase, focusing on simplifying logic, improving caching, and consolidating responsibilities. Key changes include moving Homebrew-related operations entirely to `BrewService`, introducing caching for remote formulae data, and removing redundant methods from `CommandService`.

### Refactoring and Consolidation:

* Moved the `UpdateHomebrew` method from `CommandService` to `BrewService`, centralizing all Homebrew-related operations in `BrewService`. (`internal/services/brew.go`: [[1]](diffhunk://#diff-325e1aaeb1b7863a9a86a14e08428e207edf680ddd884fc2f96d813c73bddccfL158-R225) `internal/services/command.go`: [[2]](diffhunk://#diff-477c41528e85ed9dcbf01ce5c37cb42469e502ae9afa6aeb9c49a588d4e58af4L17) [[3]](diffhunk://#diff-477c41528e85ed9dcbf01ce5c37cb42469e502ae9afa6aeb9c49a588d4e58af4L46-L53)
* Replaced `GetPrefixPath(packageName string)` with a simplified `GetPrefixPath()` method in `BrewService`, caching the prefix path instead of recalculating it for each package. (`internal/services/brew.go`: [internal/services/brew.goR6-R85](diffhunk://#diff-325e1aaeb1b7863a9a86a14e08428e207edf680ddd884fc2f96d813c73bddccfR6-R85))

### Caching and Data Management:

* Introduced caching for remote formulae data in `loadRemote`, saving the data to a local file and reusing it unless a forced download is requested. (`internal/services/brew.go`: [internal/services/brew.goL123-R184](diffhunk://#diff-325e1aaeb1b7863a9a86a14e08428e207edf680ddd884fc2f96d813c73bddccfL123-R184))
* Added a `SetupData(forceDownload bool)` method in `BrewService` to handle loading installed, remote, and analytics data in a unified way, replacing the older `LoadAllFormulae` method. (`internal/services/brew.go`: [internal/services/brew.goR94-R109](diffhunk://#diff-325e1aaeb1b7863a9a86a14e08428e207edf680ddd884fc2f96d813c73bddccfR94-R109))

### Simplification and Cleanup:

* Removed unused or redundant methods such as `LoadAllFormulae` and `GetAllFormulae` from `BrewService`. (`internal/services/brew.go`: [internal/services/brew.goR6-R85](diffhunk://#diff-325e1aaeb1b7863a9a86a14e08428e207edf680ddd884fc2f96d813c73bddccfR6-R85))
* Updated `AppService` to use the new `SetupData` and `GetFormulae` methods, simplifying logic in the `Boot` and `forceRefreshResults` methods. (`internal/services/app.go`: [[1]](diffhunk://#diff-d3e256eaf3144e3aa366f0f2bfa0cb8ccc8edc31e98bd8a5800eb6ce00029c37L74-L94) [[2]](diffhunk://#diff-d3e256eaf3144e3aa366f0f2bfa0cb8ccc8edc31e98bd8a5800eb6ce00029c37R293-L293)

These changes improve code clarity, reduce redundancy, and enhance performance by leveraging caching and consolidating responsibilities.