### PR TITLE
feat: added linux build support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,7 @@ builds:
     main: ./cmd/bbrew
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
This pull request makes a small update to the `.goreleaser.yaml` configuration file to expand platform support.

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R8): Added `linux` to the `goos` list under `builds:` to enable building for Linux platforms.