### PR TITLE
fix: use streaming to improve boot speed

### DIFF
--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -93,7 +93,7 @@ func (s *AppService) loadInitialData() {
 		app:            s.app,
 		appService:     s,
 		batchSize:      200,
-		updateInterval: 150 * time.Millisecond,
+		updateInterval: 20 * time.Millisecond,
 	}
 
 	loader.streamPackages(pkgChan, errChan)

--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -93,7 +93,7 @@ func (s *AppService) loadInitialData() {
 		app:            s.app,
 		appService:     s,
 		batchSize:      200,
-		updateInterval: 20 * time.Millisecond,
+		updateInterval: 25 * time.Millisecond,
 	}
 
 	loader.streamPackages(pkgChan, errChan)


### PR DESCRIPTION
fixes #31 

Basically instead of loading everything at boot time, you display the UI first, then stream the packages later, also since the json is big, just stream it. 

There is one downside, for a split sec, you will see the package stream. so it is more of a visual preference.