### PR TITLE
ci: add multi-platform binary artifacts to PR workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,7 +25,15 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            artifact_name: bbrew-linux-amd64
+          - os: macos-latest
+            artifact_name: bbrew-darwin-arm64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -35,3 +43,13 @@ jobs:
         run: go mod download
       - name: Build
         run: go build -v ./...
+      - name: Build binary for testing
+        run: |
+          go build -o bbrew ./cmd/bbrew
+          chmod +x bbrew
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: bbrew
+          retention-days: 7


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/quality.yml` to improve build coverage and artifact handling. The main changes include building and uploading platform-specific binaries for both Linux and macOS, making the build process more robust and suitable for multi-platform testing.

**CI/CD improvements:**

* Added a build matrix to the `build` job to run builds on both `ubuntu-latest` and `macos-latest`, allowing for platform-specific builds and testing.
* Included steps to build a binary (`bbrew`) for each platform, set executable permissions, and upload the resulting artifact with a platform-specific name and retention policy.