### PR TITLE
fix: Update filter counter in case a filter returns nothing

### DIFF
--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -314,6 +314,8 @@ func (s *AppService) setResults(data *[]models.Package, scrollToTop bool) {
 		return
 	}
 
+	// Update the filter counter even if no results are found
+	s.layout.GetSearch().UpdateCounter(len(*s.packages), len(*s.filteredPackages))
 	s.layout.GetDetails().SetContent(nil) // Clear details if no results
 }
 


### PR DESCRIPTION
The filter counter was being correctly updated in case a search filter returned something but if it didn't, it would still show an old stale value from the last time the list was not empty. This fix renders the updated filtered count irrespective of how many results were returned from the filter.