### PR TITLE
feat(brewfile): add tap support with auto-installation and caching

### DIFF
--- a/internal/models/brewfile.go
+++ b/internal/models/brewfile.go
@@ -5,3 +5,9 @@ type BrewfileEntry struct {
 	Name   string
 	IsCask bool
 }
+
+// BrewfileResult contains all parsed entries from a Brewfile
+type BrewfileResult struct {
+	Taps     []string        // List of taps to install
+	Packages []BrewfileEntry // List of packages (formulae and casks)
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for `tap` entries in Brewfile mode. When a Brewfile contains tap declarations, Bold Brew now automatically installs missing taps at startup and correctly displays packages from third-party taps.

## Changes

### New Features
- Parse `tap` entries from Brewfile alongside `brew` and `cask` entries
- Auto-install missing taps at application startup with real-time notifications
- Fetch and display package information from third-party taps
- Cache tap package metadata for faster subsequent startups

### Bug Fixes
- Fix thread safety issues with UI notifications in background goroutines by wrapping all `ShowWarning`/`ShowSuccess`/`ShowError` calls in `QueueUpdateDraw`
- Fix closure variable capture bug in tap installation loop
- Fix `executeCommand` to properly return brew command exit errors instead of always returning nil

### Improvements  
- Optimize installed package status checks using batch `brew list` calls instead of per-package checks
- Add `BrewfileResult` struct to cleanly separate taps and packages during parsing
----
Ref: https://github.com/Valkyrie00/bold-brew/issues/41