### PR TITLE
feat: Update key bindings, add open homepage and sort by type

### DIFF
--- a/internal/services/app.go
+++ b/internal/services/app.go
@@ -37,6 +37,7 @@ type AppService struct {
 	packages         *[]models.Package
 	filteredPackages *[]models.Package
 	activeFilter     FilterType
+	sortByType       bool
 	brewVersion      string
 
 	// Brewfile support

--- a/internal/services/browser.go
+++ b/internal/services/browser.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// OpenBrowser opens the specified URL in the default browser of the user.
+func OpenBrowser(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "linux":
+		cmd = "xdg-open"
+		args = []string{url}
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	default:
+		return fmt.Errorf("unsupported platform for opening browser: %s", runtime.GOOS)
+	}
+
+	return exec.Command(cmd, args...).Start()
+}

--- a/internal/services/search.go
+++ b/internal/services/search.go
@@ -53,6 +53,26 @@ func (s *AppService) search(searchText string, scrollToTop bool) {
 		})
 	}
 
+	if s.sortByType {
+		sort.Slice(filteredList, func(i, j int) bool {
+			if filteredList[i].Type != filteredList[j].Type {
+				return filteredList[i].Type < filteredList[j].Type
+			}
+			return strings.ToLower(filteredList[i].Name) < strings.ToLower(filteredList[j].Name)
+		})
+	} else if searchText != "" {
+		// sort by analytics rank when searching
+		sort.Slice(filteredList, func(i, j int) bool {
+			if filteredList[i].Analytics90dRank == 0 {
+				return false
+			}
+			if filteredList[j].Analytics90dRank == 0 {
+				return true
+			}
+			return filteredList[i].Analytics90dRank < filteredList[j].Analytics90dRank
+		})
+	}
+
 	*s.filteredPackages = filteredList
 	s.setResults(s.filteredPackages, scrollToTop)
 }

--- a/internal/ui/components/help.go
+++ b/internal/ui/components/help.go
@@ -87,20 +87,22 @@ func (h *HelpScreen) buildHelpContent() string {
 	sb.WriteString(h.formatSection("NAVIGATION"))
 	sb.WriteString(h.formatKey("↑/↓, j/k", "Navigate list"))
 	sb.WriteString(h.formatKey("/", "Focus search"))
+	sb.WriteString(h.formatKey("Shift+T", "Sort by Type"))
 	sb.WriteString(h.formatKey("Esc", "Back to table"))
 	sb.WriteString(h.formatKey("q", "Quit"))
 	sb.WriteString("\n")
 
 	// Filters section
 	sb.WriteString(h.formatSection("FILTERS"))
-	sb.WriteString(h.formatKey("f", "Toggle installed"))
-	sb.WriteString(h.formatKey("o", "Toggle outdated"))
-	sb.WriteString(h.formatKey("l", "Toggle leaves"))
-	sb.WriteString(h.formatKey("c", "Toggle casks"))
+	sb.WriteString(h.formatKey("Shift+F", "Toggle installed"))
+	sb.WriteString(h.formatKey("Shift+O", "Toggle outdated"))
+	sb.WriteString(h.formatKey("Shift+L", "Toggle leaves"))
+	sb.WriteString(h.formatKey("Shift+C", "Toggle casks"))
 	sb.WriteString("\n")
 
 	// Actions section
 	sb.WriteString(h.formatSection("ACTIONS"))
+	sb.WriteString(h.formatKey("o", "Open Homepage"))
 	sb.WriteString(h.formatKey("i", "Install selected"))
 	sb.WriteString(h.formatKey("u", "Update selected"))
 	sb.WriteString(h.formatKey("r", "Remove selected"))


### PR DESCRIPTION
# WARNING: This is a major change of keybinds

Not sure if we need to keep things the same



<img width="881" height="866" alt="image" src="https://github.com/user-attachments/assets/1e760624-a5e9-4b89-ad8b-f3d7f4effd1e" />


## Summary
This PR change the key bindings to (hopefully) be more standard. Very open to suggestions, just hoping to align bbrew with other TUI apps as much as possible

## Key Bindings Update

| Action | Old Key | New Key | Notes |
| :--- | :--- | :--- | :--- |
| **Open Homepage** | *None* | `o` | Opens the package's homepage in the default browser |
| **Sort by Type** | *None* | `Shift+T` | Toggles sorting by Type (Formula/Cask) then Name |
| **Filter Installed** | `f` | `Shift+F` | Requires Shift (or Caps Lock) |
| **Filter Outdated** | `o` | `Shift+O` | Requires Shift (or Caps Lock) |
| **Filter Leaves** | `l` | `Shift+L` | Requires Shift (or Caps Lock) |
| **Filter Casks** | `c` | `Shift+C` | Requires Shift (or Caps Lock) |


# Key Binding Comparison

This table compares the new bbrew key bindings with standard TUI applications

| Action | bbrew (New) | htop | k9s | ranger | Notes |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **Search / Filter** | `/` | `F3` / `F4` | `/` | `/` | [bbrew](cci:7://file:///var/home/james/dev/bold-brew/bbrew:0:0-0:0) matches `vim`, `k9s`, `ranger` standard |
| **Sort** | `Shift+T` (Type)<br>(Auto) | `F6`<br>`>`, `<` | `Shift+[Key]` | `o` + key | [bbrew](cci:7://file:///var/home/james/dev/bold-brew/bbrew:0:0-0:0) uses single-toggle like `k9s` (e.g. `Ctrl+s`) |
| **Open / Inspect** | `o` (Browser)<br>`Enter` (Details) | `Enter` | `Enter` | `l` / `Right`<br>`r` (with) | [bbrew](cci:7://file:///var/home/james/dev/bold-brew/bbrew:0:0-0:0) uses `o` explicitly for "external" open |
| **Quit** | `q` | `F10` / `q` | `:q` / `Ctrl+c` | `q` | Standard `q` used everywhere |
| **Quick Filters** | `Shift+[F,O,L,C]` | *N/A* | *N/A* | *N/A* | [bbrew](cci:7://file:///var/home/james/dev/bold-brew/bbrew:0:0-0:0) specific |
| **Help** | `?` | `F1` / `?` | `?` | `?` | Standard Help key |

## Design Rationale

-   **`/` for Search**: Aligns with `vim` and `k9s` for immediate familiarity.
-   **`Shift+Key` for Actions/Filters**: Similar to `k9s` using Capital letters for specific resource jumps or actions, preventing accidental triggers while typing queries.
-   **`o` for Open**: Standard in file managers (like `ranger` or `vim`'s `o`pen line concept) for opening external resources, reserving `Enter` for internal navigation.
