### PR TITLE
fix: refine flatpak integration and reduce code duplication

### DIFF
--- a/examples/linux.brewfile
+++ b/examples/linux.brewfile
@@ -1,0 +1,22 @@
+# Linux Brewfile with Flatpak support
+# Usage: bbrew -f examples/linux.brewfile
+# Requires: Linuxbrew + Flatpak (flatpak entries are skipped if not installed)
+
+# Command-line utilities
+brew "wget"
+brew "curl"
+brew "htop"
+brew "jq"
+brew "ripgrep"
+
+# Development tools
+brew "git"
+brew "node"
+brew "go"
+
+# Flatpak applications (Linux desktop apps from Flathub)
+flatpak "com.spotify.Client"
+flatpak "org.mozilla.firefox"
+flatpak "com.visualstudio.code"
+flatpak "org.gimp.GIMP"
+flatpak "org.videolan.VLC"

--- a/internal/services/brew.go
+++ b/internal/services/brew.go
@@ -2,11 +2,8 @@ package services
 
 import (
 	"bbrew/internal/models"
-	"fmt"
-	"io"
 	"os/exec"
 	"strings"
-	"sync"
 
 	"github.com/rivo/tview"
 )
@@ -126,83 +123,6 @@ func (s *BrewService) IsTapInstalled(tapName string) bool {
 }
 
 // executeCommand runs a command and captures its output, updating the provided TextView.
-func (s *BrewService) executeCommand(
-	app *tview.Application,
-	cmd *exec.Cmd,
-	outputView *tview.TextView,
-) error {
-	stdoutPipe, stdoutWriter := io.Pipe()
-	stderrPipe, stderrWriter := io.Pipe()
-	cmd.Stdout = stdoutWriter
-	cmd.Stderr = stderrWriter
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(3)
-
-	cmdErrCh := make(chan error, 1)
-
-	go func() {
-		defer wg.Done()
-		defer stdoutWriter.Close()
-		defer stderrWriter.Close()
-		cmdErrCh <- cmd.Wait()
-	}()
-
-	go func() {
-		defer wg.Done()
-		defer stdoutPipe.Close()
-		buf := make([]byte, 1024)
-		for {
-			n, err := stdoutPipe.Read(buf)
-			if n > 0 {
-				output := make([]byte, n)
-				copy(output, buf[:n])
-				app.QueueUpdateDraw(func() {
-					_, _ = outputView.Write(output) // #nosec G104
-					outputView.ScrollToEnd()
-				})
-			}
-			if err != nil {
-				if err != io.EOF {
-					app.QueueUpdateDraw(func() {
-						fmt.Fprintf(outputView, "\nError: %v\n", err)
-					})
-				}
-				break
-			}
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		defer stderrPipe.Close()
-		buf := make([]byte, 1024)
-		for {
-			n, err := stderrPipe.Read(buf)
-			if n > 0 {
-				output := make([]byte, n)
-				copy(output, buf[:n])
-				app.QueueUpdateDraw(func() {
-					_, _ = outputView.Write(output) // #nosec G104
-					outputView.ScrollToEnd()
-				})
-			}
-			if err != nil {
-				if err != io.EOF {
-					app.QueueUpdateDraw(func() {
-						fmt.Fprintf(outputView, "\nError: %v\n", err)
-					})
-				}
-				break
-			}
-		}
-	}()
-
-	wg.Wait()
-
-	return <-cmdErrCh
+func (s *BrewService) executeCommand(app *tview.Application, cmd *exec.Cmd, outputView *tview.TextView) error {
+	return ExecuteCommand(app, cmd, outputView)
 }

--- a/internal/services/brewfile.go
+++ b/internal/services/brewfile.go
@@ -89,6 +89,21 @@ func downloadBrewfile(url string) (string, error) {
 	return filepath.Clean(tempFile.Name()), nil
 }
 
+// extractQuotedValue extracts the first quoted string from a line.
+// Handles lines like: brew "git", restart_service: true # some "note"
+// by finding the first opening quote and its immediately closing pair.
+func extractQuotedValue(line string) (string, bool) {
+	start := strings.Index(line, "\"")
+	if start == -1 {
+		return "", false
+	}
+	end := strings.Index(line[start+1:], "\"")
+	if end == -1 {
+		return "", false
+	}
+	return line[start+1 : start+1+end], true
+}
+
 // parseBrewfileWithTaps parses a Brewfile and returns taps and packages separately.
 func parseBrewfileWithTaps(filepath string) (*models.BrewfileResult, error) {
 	// #nosec G304 -- filepath is user-provided via CLI flag
@@ -106,55 +121,37 @@ func parseBrewfileWithTaps(filepath string) (*models.BrewfileResult, error) {
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 
-		// Skip empty lines and comments
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		// Parse tap entries: tap "user/repo"
 		if strings.HasPrefix(line, "tap ") {
-			start := strings.Index(line, "\"")
-			end := strings.LastIndex(line, "\"")
-			if start != -1 && end != -1 && start < end {
-				tapName := line[start+1 : end]
-				result.Taps = append(result.Taps, tapName)
+			if name, ok := extractQuotedValue(line); ok {
+				result.Taps = append(result.Taps, name)
 			}
 		}
 
-		// Parse brew entries: brew "package-name"
 		if strings.HasPrefix(line, "brew ") {
-			start := strings.Index(line, "\"")
-			end := strings.LastIndex(line, "\"")
-			if start != -1 && end != -1 && start < end {
-				packageName := line[start+1 : end]
+			if name, ok := extractQuotedValue(line); ok {
 				result.Packages = append(result.Packages, models.BrewfileEntry{
-					Name:   packageName,
-					IsCask: false,
+					Name: name,
 				})
 			}
 		}
 
-		// Parse cask entries: cask "package-name"
 		if strings.HasPrefix(line, "cask ") {
-			start := strings.Index(line, "\"")
-			end := strings.LastIndex(line, "\"")
-			if start != -1 && end != -1 && start < end {
-				packageName := line[start+1 : end]
+			if name, ok := extractQuotedValue(line); ok {
 				result.Packages = append(result.Packages, models.BrewfileEntry{
-					Name:   packageName,
+					Name:   name,
 					IsCask: true,
 				})
 			}
 		}
 
-		// Parse flatpak entries: flatpak "app.id"
 		if strings.HasPrefix(line, "flatpak ") {
-			start := strings.Index(line, "\"")
-			end := strings.LastIndex(line, "\"")
-			if start != -1 && end != -1 && start < end {
-				packageName := line[start+1 : end]
+			if name, ok := extractQuotedValue(line); ok {
 				result.Packages = append(result.Packages, models.BrewfileEntry{
-					Name:      packageName,
+					Name:      name,
 					IsFlatpak: true,
 				})
 			}
@@ -220,14 +217,11 @@ func (s *AppService) loadBrewfilePackages() error {
 
 		flatpakInstalledMap, err := s.flatpakService.GetInstalledPackages()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to get installed flatpaks: %v\n", err)
 			flatpakInstalledMap = make(map[string]bool)
 		}
 
-		// Fetch metadata for richer display (Name, Version, Description)
 		flatpakMetadata, err := s.flatpakService.GetRemoteMetadata()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to get flatpak metadata: %v\n", err)
 			flatpakMetadata = make(map[string]models.Package)
 		}
 
@@ -238,14 +232,6 @@ func (s *AppService) loadBrewfilePackages() error {
 			}
 			*s.brewfilePackages = append(*s.brewfilePackages, pkg)
 			foundPackages[pkg.Name] = true
-		}
-	} else {
-		// Warn if Flatpak entries exist but binary is missing
-		for _, entry := range result.Packages {
-			if entry.IsFlatpak {
-				fmt.Fprintln(os.Stderr, "Warning: Flatpak entries found but 'flatpak' binary is not installed.")
-				break
-			}
 		}
 	}
 

--- a/internal/services/brewfile.go
+++ b/internal/services/brewfile.go
@@ -249,10 +249,10 @@ func (s *AppService) loadBrewfilePackages() error {
 		}
 	}
 
-	// Collect entries not found in main list (tap packages)
+	// Collect entries not found in main list (tap packages, excluding flatpak)
 	var tapEntries []models.BrewfileEntry
 	for _, entry := range result.Packages {
-		if !foundPackages[entry.Name] {
+		if !foundPackages[entry.Name] && !entry.IsFlatpak {
 			tapEntries = append(tapEntries, entry)
 		}
 	}

--- a/internal/services/command.go
+++ b/internal/services/command.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/rivo/tview"
+)
+
+// ExecuteCommand runs a command, streaming stdout/stderr to a tview.TextView in real time.
+func ExecuteCommand(app *tview.Application, cmd *exec.Cmd, outputView *tview.TextView) error {
+	stdoutPipe, stdoutWriter := io.Pipe()
+	stderrPipe, stderrWriter := io.Pipe()
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	cmdErrCh := make(chan error, 1)
+
+	go func() {
+		defer wg.Done()
+		defer stdoutWriter.Close()
+		defer stderrWriter.Close()
+		cmdErrCh <- cmd.Wait()
+	}()
+
+	streamPipe := func(pipe *io.PipeReader) {
+		defer wg.Done()
+		defer pipe.Close()
+		buf := make([]byte, 1024)
+		for {
+			n, err := pipe.Read(buf)
+			if n > 0 {
+				output := make([]byte, n)
+				copy(output, buf[:n])
+				app.QueueUpdateDraw(func() {
+					_, _ = outputView.Write(output) // #nosec G104
+					outputView.ScrollToEnd()
+				})
+			}
+			if err != nil {
+				if err != io.EOF {
+					app.QueueUpdateDraw(func() {
+						fmt.Fprintf(outputView, "\nError: %v\n", err)
+					})
+				}
+				break
+			}
+		}
+	}
+
+	go streamPipe(stdoutPipe)
+	go streamPipe(stderrPipe)
+
+	wg.Wait()
+
+	return <-cmdErrCh
+}

--- a/internal/services/flatpak.go
+++ b/internal/services/flatpak.go
@@ -2,11 +2,8 @@ package services
 
 import (
 	"bbrew/internal/models"
-	"fmt"
-	"io"
 	"os/exec"
 	"strings"
-	"sync"
 
 	"github.com/rivo/tview"
 )
@@ -20,6 +17,7 @@ type FlatpakServiceInterface interface {
 	InstallPackage(info models.Package, app *tview.Application, outputView *tview.TextView) error
 	RemovePackage(info models.Package, app *tview.Application, outputView *tview.TextView) error
 	UpdatePackage(info models.Package, app *tview.Application, outputView *tview.TextView) error
+	UpdateAllPackages(app *tview.Application, outputView *tview.TextView) error
 }
 
 // FlatpakService implements FlatpakServiceInterface.
@@ -51,21 +49,23 @@ func (s *FlatpakService) EnsureFlathubRemote(app *tview.Application, outputView 
 	return s.executeCommand(app, addCmd, outputView)
 }
 
-// GetInstalledPackages returns a map of installed Flatpak application IDs.
+// GetInstalledPackages returns a map of installed Flatpak application IDs (both user and system).
 func (s *FlatpakService) GetInstalledPackages() (map[string]bool, error) {
-	cmd := exec.Command("flatpak", "list", "--app", "--columns=application")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-
 	installed := make(map[string]bool)
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	for _, line := range lines {
-		if id := strings.TrimSpace(line); id != "" {
-			installed[id] = true
+
+	for _, scope := range []string{"--user", "--system"} {
+		cmd := exec.Command("flatpak", "list", scope, "--app", "--columns=application") // #nosec G204 - scope is a hardcoded constant
+		output, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+			if id := strings.TrimSpace(line); id != "" {
+				installed[id] = true
+			}
 		}
 	}
+
 	return installed, nil
 }
 
@@ -118,101 +118,29 @@ func (s *FlatpakService) GetRemoteMetadata() (map[string]models.Package, error) 
 
 // InstallPackage installs a Flatpak from Flathub.
 func (s *FlatpakService) InstallPackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {
-	cmd := exec.Command("flatpak", "install", "--user", "-y", "flathub", info.Name)
+	cmd := exec.Command("flatpak", "install", "--user", "-y", "flathub", info.Name) // #nosec G204
 	return s.executeCommand(app, cmd, outputView)
 }
 
 // RemovePackage uninstalls a Flatpak.
 func (s *FlatpakService) RemovePackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {
-	cmd := exec.Command("flatpak", "uninstall", "--user", "-y", info.Name)
+	cmd := exec.Command("flatpak", "uninstall", "--user", "-y", info.Name) // #nosec G204
 	return s.executeCommand(app, cmd, outputView)
 }
 
 // UpdatePackage updates a specific Flatpak.
 func (s *FlatpakService) UpdatePackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {
-	cmd := exec.Command("flatpak", "update", "--user", "-y", info.Name)
+	cmd := exec.Command("flatpak", "update", "--user", "-y", info.Name) // #nosec G204
+	return s.executeCommand(app, cmd, outputView)
+}
+
+// UpdateAllPackages updates all installed user-level Flatpak applications.
+func (s *FlatpakService) UpdateAllPackages(app *tview.Application, outputView *tview.TextView) error {
+	cmd := exec.Command("flatpak", "update", "--user", "-y") // #nosec G204
 	return s.executeCommand(app, cmd, outputView)
 }
 
 // executeCommand runs a command and captures its output, updating the provided TextView.
-// Duplicated from BrewService for modularity as requested (no shared base yet).
-func (s *FlatpakService) executeCommand(
-	app *tview.Application,
-	cmd *exec.Cmd,
-	outputView *tview.TextView,
-) error {
-	stdoutPipe, stdoutWriter := io.Pipe()
-	stderrPipe, stderrWriter := io.Pipe()
-	cmd.Stdout = stdoutWriter
-	cmd.Stderr = stderrWriter
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(3)
-
-	cmdErrCh := make(chan error, 1)
-
-	go func() {
-		defer wg.Done()
-		defer stdoutWriter.Close()
-		defer stderrWriter.Close()
-		cmdErrCh <- cmd.Wait()
-	}()
-
-	go func() {
-		defer wg.Done()
-		defer stdoutPipe.Close()
-		buf := make([]byte, 1024)
-		for {
-			n, err := stdoutPipe.Read(buf)
-			if n > 0 {
-				output := make([]byte, n)
-				copy(output, buf[:n])
-				app.QueueUpdateDraw(func() {
-					_, _ = outputView.Write(output)
-					outputView.ScrollToEnd()
-				})
-			}
-			if err != nil {
-				if err != io.EOF {
-					app.QueueUpdateDraw(func() {
-						fmt.Fprintf(outputView, "\nError: %v\n", err)
-					})
-				}
-				break
-			}
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		defer stderrPipe.Close()
-		buf := make([]byte, 1024)
-		for {
-			n, err := stderrPipe.Read(buf)
-			if n > 0 {
-				output := make([]byte, n)
-				copy(output, buf[:n])
-				app.QueueUpdateDraw(func() {
-					_, _ = outputView.Write(output)
-					outputView.ScrollToEnd()
-				})
-			}
-			if err != nil {
-				if err != io.EOF {
-					app.QueueUpdateDraw(func() {
-						fmt.Fprintf(outputView, "\nError: %v\n", err)
-					})
-				}
-				break
-			}
-		}
-	}()
-
-	wg.Wait()
-
-	return <-cmdErrCh
+func (s *FlatpakService) executeCommand(app *tview.Application, cmd *exec.Cmd, outputView *tview.TextView) error {
+	return ExecuteCommand(app, cmd, outputView)
 }

--- a/internal/services/flatpak.go
+++ b/internal/services/flatpak.go
@@ -38,17 +38,16 @@ func (s *FlatpakService) IsFlatpakInstalled() bool {
 	return err == nil
 }
 
-// EnsureFlathubRemote checks if the flathub remote exists, and adds it if missing.
+// EnsureFlathubRemote ensures flathub is available as a user-level remote.
+// Even if flathub exists at system level, --user installs need a user-level remote.
 func (s *FlatpakService) EnsureFlathubRemote(app *tview.Application, outputView *tview.TextView) error {
-	// Check if flathub exists
-	checkCmd := exec.Command("flatpak", "remote-list")
+	checkCmd := exec.Command("flatpak", "remote-list", "--user")
 	output, err := checkCmd.Output()
 	if err == nil && strings.Contains(string(output), "flathub") {
-		return nil // Already exists
+		return nil
 	}
 
-	// Add flathub
-	addCmd := exec.Command("flatpak", "remote-add", "--if-not-exists", "flathub", "https://dl.flathub.org/repo/flathub.flatpakrepo")
+	addCmd := exec.Command("flatpak", "remote-add", "--user", "--if-not-exists", "flathub", "https://dl.flathub.org/repo/flathub.flatpakrepo")
 	return s.executeCommand(app, addCmd, outputView)
 }
 
@@ -77,7 +76,7 @@ func (s *FlatpakService) GetRemoteMetadata() (map[string]models.Package, error) 
 		return s.cachedMetadata, nil
 	}
 
-	cmd := exec.Command("flatpak", "remote-ls", "flathub", "--app", "--columns=application,name,version,description")
+	cmd := exec.Command("flatpak", "remote-ls", "--user", "flathub", "--app", "--columns=application,name,version,description")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -119,22 +118,19 @@ func (s *FlatpakService) GetRemoteMetadata() (map[string]models.Package, error) 
 
 // InstallPackage installs a Flatpak from Flathub.
 func (s *FlatpakService) InstallPackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {
-	// flatpak install -y flathub <app-id>
-	cmd := exec.Command("flatpak", "install", "-y", "flathub", info.Name)
+	cmd := exec.Command("flatpak", "install", "--user", "-y", "flathub", info.Name)
 	return s.executeCommand(app, cmd, outputView)
 }
 
 // RemovePackage uninstalls a Flatpak.
 func (s *FlatpakService) RemovePackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {
-	// flatpak uninstall -y <app-id>
-	cmd := exec.Command("flatpak", "uninstall", "-y", info.Name)
+	cmd := exec.Command("flatpak", "uninstall", "--user", "-y", info.Name)
 	return s.executeCommand(app, cmd, outputView)
 }
 
 // UpdatePackage updates a specific Flatpak.
 func (s *FlatpakService) UpdatePackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {
-	// flatpak update -y <app-id>
-	cmd := exec.Command("flatpak", "update", "-y", info.Name)
+	cmd := exec.Command("flatpak", "update", "--user", "-y", info.Name)
 	return s.executeCommand(app, cmd, outputView)
 }
 

--- a/internal/services/flatpak.go
+++ b/internal/services/flatpak.go
@@ -23,7 +23,9 @@ type FlatpakServiceInterface interface {
 }
 
 // FlatpakService implements FlatpakServiceInterface.
-type FlatpakService struct{}
+type FlatpakService struct {
+	cachedMetadata map[string]models.Package
+}
 
 // NewFlatpakService creates a new instance of FlatpakService.
 var NewFlatpakService = func() FlatpakServiceInterface {
@@ -69,9 +71,12 @@ func (s *FlatpakService) GetInstalledPackages() (map[string]bool, error) {
 }
 
 // GetRemoteMetadata fetches metadata (name, version, description) for all applications in Flathub.
-// This is an expensive operation so it should be used sparingly or cached at the app level.
+// Results are cached in memory to avoid repeated expensive `flatpak remote-ls` calls.
 func (s *FlatpakService) GetRemoteMetadata() (map[string]models.Package, error) {
-	// Fetch columns: application ID, name, version, description
+	if s.cachedMetadata != nil {
+		return s.cachedMetadata, nil
+	}
+
 	cmd := exec.Command("flatpak", "remote-ls", "flathub", "--app", "--columns=application,name,version,description")
 	output, err := cmd.Output()
 	if err != nil {
@@ -97,9 +102,6 @@ func (s *FlatpakService) GetRemoteMetadata() (map[string]models.Package, error) 
 			if len(parts) >= 4 {
 				desc = strings.TrimSpace(parts[3])
 			}
-			
-			// Some rows might have missing fields that flatpak leaves as empty strings or skips?
-			// Checking actual output suggests it tabs empty fields correctly.
 
 			metadata[id] = models.Package{
 				Name:        id,
@@ -110,9 +112,10 @@ func (s *FlatpakService) GetRemoteMetadata() (map[string]models.Package, error) 
 			}
 		}
 	}
+
+	s.cachedMetadata = metadata
 	return metadata, nil
 }
-
 
 // InstallPackage installs a Flatpak from Flathub.
 func (s *FlatpakService) InstallPackage(info models.Package, app *tview.Application, outputView *tview.TextView) error {

--- a/internal/services/input.go
+++ b/internal/services/input.go
@@ -402,11 +402,20 @@ func (s *InputService) handleUpdateAllPackagesEvent() {
 		s.closeModal()
 		s.layout.GetOutput().Clear()
 		go func() {
-			s.layout.GetNotifier().ShowWarning("Updating all Packages...")
+			s.layout.GetNotifier().ShowWarning("Updating all Homebrew packages...")
 			if err := s.brewService.UpdateAllPackages(s.appService.app, s.layout.GetOutput().View()); err != nil {
-				s.layout.GetNotifier().ShowError("Failed to update all Packages")
+				s.layout.GetNotifier().ShowError("Failed to update Homebrew packages")
 				return
 			}
+
+			if s.flatpakService.IsFlatpakInstalled() {
+				s.layout.GetNotifier().ShowWarning("Updating all Flatpak packages...")
+				if err := s.flatpakService.UpdateAllPackages(s.appService.app, s.layout.GetOutput().View()); err != nil {
+					s.layout.GetNotifier().ShowError("Failed to update Flatpak packages")
+					return
+				}
+			}
+
 			s.layout.GetNotifier().ShowSuccess("Updated all Packages")
 			s.appService.forceRefreshResults()
 		}()

--- a/internal/services/search.go
+++ b/internal/services/search.go
@@ -33,6 +33,7 @@ func (s *AppService) search(searchText string, scrollToTop bool) {
 		searchTextLower := strings.ToLower(searchText)
 		for _, info := range *sourceList {
 			if strings.Contains(strings.ToLower(info.Name), searchTextLower) ||
+				strings.Contains(strings.ToLower(info.DisplayName), searchTextLower) ||
 				strings.Contains(strings.ToLower(info.Description), searchTextLower) {
 				if !uniquePackages[info.Name] {
 					filteredList = append(filteredList, info)
@@ -121,11 +122,11 @@ func (s *AppService) setResults(data *[]models.Package, scrollToTop bool) {
 
 	for i, info := range *data {
 		// Type cell with escaped brackets
-		typeTag := "🧪" // Formula
+		typeTag := tview.Escape("[F]") // Formula
 		if info.Type == models.PackageTypeCask {
-			typeTag = "🪣" // Cask
+			typeTag = tview.Escape("[C]") // Cask
 		} else if info.Type == models.PackageTypeFlatpak {
-			typeTag = "📦" // Flatpak
+			typeTag = tview.Escape("[P]") // Flatpak
 		}
 		typeCell := tview.NewTableCell(typeTag).SetSelectable(true).SetAlign(tview.AlignLeft)
 
@@ -137,8 +138,7 @@ func (s *AppService) setResults(data *[]models.Package, scrollToTop bool) {
 		}
 
 		// Name cell
-		// Name cell
-		nameCell := tview.NewTableCell(info.DisplayName).SetSelectable(true)
+		nameCell := tview.NewTableCell(info.Name).SetSelectable(true)
 		if info.LocallyInstalled {
 			nameCell.SetTextColor(tcell.ColorGreen)
 		}

--- a/internal/ui/components/details.go
+++ b/internal/ui/components/details.go
@@ -47,14 +47,14 @@ func (d *Details) SetContent(pkg *models.Package) {
 		}
 	}
 
-	// Type tag
-	typeTag := "🧪" // Formula
+	// Type tag with escaped brackets
+	typeTag := tview.Escape("[F]") // Formula
 	typeLabel := "Formula"
 	if pkg.Type == models.PackageTypeCask {
-		typeTag = "🪣" // Cask
+		typeTag = tview.Escape("[C]") // Cask
 		typeLabel = "Cask"
 	} else if pkg.Type == models.PackageTypeFlatpak {
-		typeTag = "📦" // Flatpak
+		typeTag = tview.Escape("[P]") // Flatpak
 		typeLabel = "Flatpak"
 	}
 
@@ -65,13 +65,13 @@ func (d *Details) SetContent(pkg *models.Package) {
 	basicInfo := fmt.Sprintf(
 		"[yellow::b]%s[-]\n%s\n"+
 			"[blue]• Type:[-] %s %s\n"+
-			"[blue]• ID:[-] %s\n"+
 			"[blue]• Name:[-] %s\n"+
+			"[blue]• Display Name:[-] %s\n"+
 			"[blue]• Version:[-] %s\n"+
 			"[blue]• Status:[-] %s\n"+
 			"[blue]• Homepage:[-] %s\n\n"+
 			"[yellow::b]Description[-]\n%s\n%s",
-		pkg.DisplayName, separator,
+		pkg.Name, separator,
 		typeTag, typeLabel,
 		pkg.Name,
 		pkg.DisplayName,


### PR DESCRIPTION
Summary
Post-merge refinements for PR #55 (flatpak support). Fixes several bugs found during real-world testing on RHEL, improves terminal compatibility, and reduces code duplication.

Changes
- Terminal compatibility: Reverted emoji type indicators to text tags ([F]/[C]/[P]) for reliable rendering across all terminals
- Search fix: Search now matches both Name and DisplayName, so flatpak packages can be found by their human-readable name
- Flatpak entry guard: Flatpak entries no longer leak into tap package resolution when flatpak is not installed
- User-level operations: All flatpak commands use --user flag to avoid permission errors on systems where system-wide installs are restricted
- Flathub remote: EnsureFlathubRemote correctly sets up a user-level remote, even when flathub already exists at system level
- Installed detection: GetInstalledPackages now checks both --user and --system scopes
- Metadata caching: GetRemoteMetadata results are cached in memory to avoid blocking startup on repeated calls
- Brewfile parsing: Fixed LastIndex bug that caused incorrect parsing when lines contain quotes in comments or options (affects tap, brew, cask, and flatpak entries)
- Update All: Ctrl+U now updates both Homebrew and Flatpak packages
- Code dedup: Extracted shared ExecuteCommand utility, removing ~140 lines of duplicated code between BrewService and FlatpakService
-Example: Added examples/linux.brewfile with mixed brew + flatpak entries