### PR TITLE
ci: update GitHub Actions to Node 24 and harden pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -13,12 +13,12 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.5.0
           skip-cache: true
@@ -35,8 +35,8 @@ jobs:
             artifact_name: bbrew-darwin-arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Get dependencies
@@ -48,7 +48,7 @@ jobs:
           go build -o bbrew ./cmd/bbrew
           chmod +x bbrew
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact_name }}
           path: bbrew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -34,21 +34,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.27.1
         with:
           args: '-no-fail -fmt sarif -out results.sarif ./...'
 
       - name: Upload SARIF file
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ensure clean state (no Homebrew)
         run: |
@@ -59,7 +59,7 @@ jobs:
     runs-on: macos-14  # M1 runner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ensure clean state (no Homebrew)
         run: |
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pre-install Homebrew
         run: |

--- a/internal/services/search.go
+++ b/internal/services/search.go
@@ -122,11 +122,14 @@ func (s *AppService) setResults(data *[]models.Package, scrollToTop bool) {
 
 	for i, info := range *data {
 		// Type cell with escaped brackets
-		typeTag := tview.Escape("[F]") // Formula
-		if info.Type == models.PackageTypeCask {
-			typeTag = tview.Escape("[C]") // Cask
-		} else if info.Type == models.PackageTypeFlatpak {
-			typeTag = tview.Escape("[P]") // Flatpak
+		var typeTag string
+		switch info.Type {
+		case models.PackageTypeCask:
+			typeTag = tview.Escape("[C]")
+		case models.PackageTypeFlatpak:
+			typeTag = tview.Escape("[P]")
+		default:
+			typeTag = tview.Escape("[F]")
 		}
 		typeCell := tview.NewTableCell(typeTag).SetSelectable(true).SetAlign(tview.AlignLeft)
 

--- a/internal/ui/components/details.go
+++ b/internal/ui/components/details.go
@@ -48,14 +48,17 @@ func (d *Details) SetContent(pkg *models.Package) {
 	}
 
 	// Type tag with escaped brackets
-	typeTag := tview.Escape("[F]") // Formula
-	typeLabel := "Formula"
-	if pkg.Type == models.PackageTypeCask {
-		typeTag = tview.Escape("[C]") // Cask
+	var typeTag, typeLabel string
+	switch pkg.Type {
+	case models.PackageTypeCask:
+		typeTag = tview.Escape("[C]")
 		typeLabel = "Cask"
-	} else if pkg.Type == models.PackageTypeFlatpak {
-		typeTag = tview.Escape("[P]") // Flatpak
+	case models.PackageTypeFlatpak:
+		typeTag = tview.Escape("[P]")
 		typeLabel = "Flatpak"
+	default:
+		typeTag = tview.Escape("[F]")
+		typeLabel = "Formula"
 	}
 
 	// Section separator


### PR DESCRIPTION
GitHub runners now default to Node 24 (June 2026), deprecating Node 20. Bumped all actions to their Node 24-compatible releases:
- actions/checkout v4 → v5
- actions/setup-go v5 → v6
- actions/upload-artifact v4 → v5
- github/codeql-action/upload-sarif v3 → v4
- goreleaser/goreleaser-action v6 → v7

Pin securego/gosec from master to @v2.27.1 for reproducible builds and supply chain safety. Add Dependabot config to automatically track weekly GitHub Actions updates.