### PR TITLE
chore: update install instructions to use homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Install Homebrew + Bold Brew with a single command:
 ### Via Homebrew
 
 ```sh
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 ```
 
 ### Manual Download

--- a/docs/blog/bold-brew-2-0-cask-support.html
+++ b/docs/blog/bold-brew-2-0-cask-support.html
@@ -241,7 +241,7 @@ brew upgrade bbrew
 </code></pre>
 <h3>For New Users</h3>
 <p>Install Bold Brew via Homebrew:</p>
-<pre><code class="language-bash">brew install Valkyrie00/bbrew/bbrew
+<pre><code class="language-bash">brew install bbrew
 </code></pre>
 <p>Or download from the <a href="https://github.com/Valkyrie00/bold-brew/releases">releases page</a>.</p>
 <h2>📖 Using the New Features</h2>

--- a/docs/blog/bold-brew-2-3-homebrew-6-vulns.html
+++ b/docs/blog/bold-brew-2-3-homebrew-6-vulns.html
@@ -229,7 +229,7 @@ flatpak &quot;org.mozilla.firefox&quot;
 <pre><code>brew upgrade bbrew
 </code></pre>
 <p>Or install fresh:</p>
-<pre><code>brew install Valkyrie00/bbrew/bbrew
+<pre><code>brew install bbrew
 </code></pre>
 <p>Check out the <a href="/changelog/">full changelog</a> for the complete list of changes.</p>
 <hr>

--- a/docs/blog/brewfile-mode-remote-support.html
+++ b/docs/blog/brewfile-mode-remote-support.html
@@ -210,7 +210,7 @@ bbrew -f https://example.com/brewfiles/frontend-dev.Brewfile
 
 Install our recommended tools:
 \`\`\`bash
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 bbrew -f https://our-company.com/dev-setup.Brewfile
 \`\`\`
 </code></pre>

--- a/docs/blog/managing-homebrew-packages.html
+++ b/docs/blog/managing-homebrew-packages.html
@@ -199,7 +199,7 @@
 </ol>
 <h2>Installation</h2>
 <p>Install Bold Brew using Homebrew:</p>
-<pre><code class="language-bash">brew install Valkyrie00/bbrew/bbrew
+<pre><code class="language-bash">brew install bbrew
 </code></pre>
 <h2>Key Features</h2>
 <h3>1. Package Search</h3>

--- a/docs/blog/top-homebrew-packages-for-developers.html
+++ b/docs/blog/top-homebrew-packages-for-developers.html
@@ -279,7 +279,7 @@
 </ol>
 <h3>Installing Bold Brew</h3>
 <p>You can install Bold Brew with a simple command:</p>
-<pre><code class="language-bash">brew install Valkyrie00/bbrew/bbrew
+<pre><code class="language-bash">brew install bbrew
 </code></pre>
 <p>Once installed, simply run:</p>
 <pre><code class="language-bash">bbrew
@@ -296,7 +296,7 @@
 <h2>Conclusion</h2>
 <p>The Homebrew packages listed in this article are essential tools for any macOS developer in 2024. To manage them efficiently, Bold Brew offers a superior user experience that will save you time and frustration.</p>
 <p>If you haven&#39;t already, try Bold Brew today:</p>
-<pre><code class="language-bash">brew install Valkyrie00/bbrew/bbrew
+<pre><code class="language-bash">brew install bbrew
 </code></pre>
 <p>Discover a more elegant and productive way to interact with Homebrew, and focus on what really matters: writing exceptional code.</p>
 <p><strong>Do you have other favorite Homebrew packages that you think should be on the list? Share them in the comments below!</strong></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -210,7 +210,7 @@
                         </div>
                         <p class="text-center">Already have Homebrew? Install directly:</p>
                         <div class="code-block" style="max-width: 500px; margin: 0 auto 1rem;">
-                            <pre><code><span class="prompt">$</span> brew install Valkyrie00/bbrew/bbrew</code></pre>
+                            <pre><code><span class="prompt">$</span> brew install bbrew</code></pre>
                             <button class="copy-btn" onclick="copyToClipboard(this)" aria-label="Copy command">
                                 <span class="copy-icon">⧉</span>
                                 <span class="copy-text">Copy</span>
@@ -450,7 +450,7 @@
                             <div id="faq2" class="faq-answer collapse" data-bs-parent="#faqAccordion">
                                 <p>You can install Bold Brew in two ways:</p>
                                 <ol>
-                                    <li>Using Homebrew: <code>brew install Valkyrie00/bbrew/bbrew</code></li>
+                                    <li>Using Homebrew: <code>brew install bbrew</code></li>
                                     <li>Downloading the latest release from our GitHub repository</li>
                                 </ol>
                             </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,25 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bold-brew.com/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://bold-brew.com/blog/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bold-brew.com/docs/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bold-brew.com/changelog/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,7 @@ install_homebrew() {
 install_boldbrew() {
     info "Installing Bold Brew..."
     
-    brew install Valkyrie00/bbrew/bbrew
+    brew install bbrew
     
     success "Bold Brew installed successfully!"
 }
@@ -214,7 +214,7 @@ main() {
     # Check if bbrew is already installed
     if command_exists bbrew; then
         warn "Bold Brew is already installed. Upgrading..."
-        brew upgrade bbrew 2>/dev/null || brew install Valkyrie00/bbrew/bbrew
+        brew upgrade bbrew 2>/dev/null || brew install bbrew
     else
         install_boldbrew
     fi

--- a/site/content/blog/bold-brew-2-0-cask-support.md
+++ b/site/content/blog/bold-brew-2-0-cask-support.md
@@ -95,7 +95,7 @@ brew upgrade bbrew
 Install Bold Brew via Homebrew:
 
 ```bash
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 ```
 
 Or download from the [releases page](https://github.com/Valkyrie00/bold-brew/releases).

--- a/site/content/blog/bold-brew-2-3-homebrew-6-vulns.md
+++ b/site/content/blog/bold-brew-2-3-homebrew-6-vulns.md
@@ -100,7 +100,7 @@ brew upgrade bbrew
 Or install fresh:
 
 ```
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 ```
 
 Check out the [full changelog](/changelog/) for the complete list of changes.

--- a/site/content/blog/brewfile-mode-remote-support.md
+++ b/site/content/blog/brewfile-mode-remote-support.md
@@ -63,7 +63,7 @@ Share a single URL with colleagues or include it in your README:
 
 Install our recommended tools:
 \`\`\`bash
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 bbrew -f https://our-company.com/dev-setup.Brewfile
 \`\`\`
 ```

--- a/site/content/blog/managing-homebrew-packages.md
+++ b/site/content/blog/managing-homebrew-packages.md
@@ -33,7 +33,7 @@ Bold Brew offers several advantages over traditional command-line package manage
 Install Bold Brew using Homebrew:
 
 ```bash
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 ```
 
 ## Key Features

--- a/site/content/blog/top-homebrew-packages-for-developers.md
+++ b/site/content/blog/top-homebrew-packages-for-developers.md
@@ -189,7 +189,7 @@ Bold Brew (bbrew) solves these challenges by offering an elegant TUI (Terminal U
 You can install Bold Brew with a simple command:
 
 ```bash
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 ```
 
 Once installed, simply run:
@@ -216,7 +216,7 @@ The Homebrew packages listed in this article are essential tools for any macOS d
 If you haven't already, try Bold Brew today:
 
 ```bash
-brew install Valkyrie00/bbrew/bbrew
+brew install bbrew
 ```
 
 Discover a more elegant and productive way to interact with Homebrew, and focus on what really matters: writing exceptional code.

--- a/site/templates/index.ejs
+++ b/site/templates/index.ejs
@@ -71,7 +71,7 @@
                         </div>
                         <p class="text-center">Already have Homebrew? Install directly:</p>
                         <div class="code-block" style="max-width: 500px; margin: 0 auto 1rem;">
-                            <pre><code><span class="prompt">$</span> brew install Valkyrie00/bbrew/bbrew</code></pre>
+                            <pre><code><span class="prompt">$</span> brew install bbrew</code></pre>
                             <button class="copy-btn" onclick="copyToClipboard(this)" aria-label="Copy command">
                                 <span class="copy-icon">⧉</span>
                                 <span class="copy-text">Copy</span>
@@ -289,7 +289,7 @@
                             <div id="faq2" class="faq-answer collapse" data-bs-parent="#faqAccordion">
                                 <p>You can install Bold Brew in two ways:</p>
                                 <ol>
-                                    <li>Using Homebrew: <code>brew install Valkyrie00/bbrew/bbrew</code></li>
+                                    <li>Using Homebrew: <code>brew install bbrew</code></li>
                                     <li>Downloading the latest release from our GitHub repository</li>
                                 </ol>
                             </div>


### PR DESCRIPTION
bbrew is now available directly from homebrew-core (PR #291114). Remove all references to the custom tap (Valkyrie00/bbrew).

Ref: #60 