### PR TITLE
Fix false-positive outdated status for auto_updates casks

### DIFF
--- a/internal/models/cask.go
+++ b/internal/models/cask.go
@@ -14,6 +14,7 @@ type Cask struct {
 	Installed             *string            `json:"installed"`      // Null if not installed, version string if installed
 	InstalledTime         *int64             `json:"installed_time"` // Unix timestamp
 	Outdated              bool               `json:"outdated"`
+	AutoUpdates           bool               `json:"auto_updates"` // App updates itself; Homebrew's version lags behind
 	SHA256                string             `json:"sha256"`
 	Deprecated            bool               `json:"deprecated"`
 	DeprecationDate       interface{}        `json:"deprecation_date"`

--- a/internal/models/package.go
+++ b/internal/models/package.go
@@ -72,8 +72,11 @@ func NewPackageFromCask(c *Cask) Package {
 	// Detect outdated: use Homebrew's flag OR compare installed vs latest version.
 	// Some casks don't set Outdated correctly in the JSON, so we also check
 	// if the installed version differs from the available version.
+	// Skip the version comparison for auto_updates casks: the app updates
+	// itself, so the Caskroom receipt is stale by design and a mismatch is
+	// not a real update (same reason `brew outdated` skips them by default).
 	outdated := c.Outdated
-	if !outdated && c.Installed != nil && c.Version != "" && c.Version != "latest" {
+	if !outdated && !c.AutoUpdates && c.Installed != nil && c.Version != "" && c.Version != "latest" {
 		outdated = *c.Installed != c.Version
 	}
 

--- a/internal/models/package_test.go
+++ b/internal/models/package_test.go
@@ -128,6 +128,42 @@ func TestNewPackageFromCask_OutdatedByVersionMismatch(t *testing.T) {
 	}
 }
 
+func TestNewPackageFromCask_NotOutdatedWhenAutoUpdates(t *testing.T) {
+	installedVersion := "4.8.3" // stale receipt: the app self-updated past this
+	c := &Cask{
+		Token:            "macfuse",
+		Name:             []string{"macFUSE"},
+		Version:          "5.2.0",
+		Installed:        &installedVersion,
+		Outdated:         false, // Homebrew skips auto_updates casks by default
+		AutoUpdates:      true,
+		LocallyInstalled: true,
+	}
+
+	pkg := NewPackageFromCask(c)
+	if pkg.Outdated {
+		t.Error("Outdated = true, want false (auto_updates cask: receipt mismatch is not a real update)")
+	}
+}
+
+func TestNewPackageFromCask_OutdatedWhenAutoUpdatesFlaggedByHomebrew(t *testing.T) {
+	installedVersion := "1.0.0"
+	c := &Cask{
+		Token:            "self-updating-app",
+		Name:             []string{"Self Updating App"},
+		Version:          "2.0.0",
+		Installed:        &installedVersion,
+		Outdated:         true, // e.g. brew outdated --greedy would report this
+		AutoUpdates:      true,
+		LocallyInstalled: true,
+	}
+
+	pkg := NewPackageFromCask(c)
+	if !pkg.Outdated {
+		t.Error("Outdated = false, want true (Homebrew's own flag must still be respected)")
+	}
+}
+
 func TestNewPackageFromCask_NotOutdatedWhenVersionLatest(t *testing.T) {
 	installedVersion := "latest"
 	c := &Cask{


### PR DESCRIPTION
## Problem

Every cask with `auto_updates: true` (Warp, Tailscale, macFUSE, Antigravity, …) shows up as **Update available** in the Outdated filter, even when the installed app is fully up to date.

These apps update themselves outside Homebrew, so the Caskroom receipt version is stale by design. `NewPackageFromCask` compares that receipt against the cask's latest version and flags any mismatch as outdated — which is a false positive for self-updating apps. This is why `brew outdated --cask` reports nothing while bbrew shows several "outdated" casks (it effectively behaves like `brew outdated --greedy`).

It can even suggest a downgrade: on my machine macFUSE self-updated to 5.3.3 while the cask definition is still 5.2.0 (receipt: 4.8.3). bbrew shows "Update available"; upgrading would install 5.2.0 over 5.3.3.

```
$ brew outdated --cask
(nothing)

$ brew info --json=v2 --cask macfuse | jq '.casks[0] | {version, installed, auto_updates, outdated}'
{
  "version": "5.2.0",
  "installed": "4.8.3",
  "auto_updates": true,
  "outdated": false
}
```

## Fix

Parse the `auto_updates` field (present in both `brew info --json=v2` and the formulae.brew.sh API) and skip the version-mismatch fallback for those casks — matching the default behavior of `brew outdated`, which only includes auto_updates casks with `--greedy`. Homebrew's own `outdated` flag is still respected, so nothing changes for users who somehow get a true flag from brew.

The existing fallback behavior for regular casks is unchanged (all existing tests still pass; two new tests cover the auto_updates cases).

If you'd prefer to keep the greedy behavior available, this could later be a toggle (like `brew outdated --greedy`), but the non-greedy default seems like the right baseline since it matches Homebrew itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
