### PR TITLE
fix: version check now resolves from user's install source

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   ![Quality](https://github.com/Valkyrie00/bold-brew/workflows/Quality/badge.svg)
   ![Security](https://github.com/Valkyrie00/bold-brew/workflows/Security/badge.svg)
   ![Downloads](https://img.shields.io/github/downloads/Valkyrie00/bold-brew/total)
+  ![Homebrew Installs](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fformulae.brew.sh%2Fapi%2Fformula%2Fbbrew.json&query=%24.analytics.install.30d.bbrew&label=homebrew%20installs%20%2830d%29&logo=homebrew&color=FBB040)
 
   [Website](https://bold-brew.com/) · [Changelog](https://github.com/Valkyrie00/bold-brew/releases) · [Report Bug](https://github.com/Valkyrie00/bold-brew/issues/new?labels=bug) · [Request Feature](https://github.com/Valkyrie00/bold-brew/issues/new?labels=enhancement)
 

--- a/internal/services/selfupdate.go
+++ b/internal/services/selfupdate.go
@@ -23,14 +23,17 @@ var NewSelfUpdateService = func() SelfUpdateServiceInterface {
 }
 
 // CheckForUpdates checks for the latest version of the Bold Brew package using Homebrew.
+// It queries "bbrew" without a tap prefix so it resolves to whichever source the user
+// installed from (homebrew-core or the tap), ensuring the notification matches what
+// the user can actually upgrade to.
 func (s *SelfUpdateService) CheckForUpdates(ctx context.Context) (string, error) {
-	cmd := brewCommandContext(ctx, "info", "--json=v1", "valkyrie00/bbrew/bbrew")
+	cmd := brewCommandContext(ctx, "info", "--json=v1", "bbrew")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("context cancelled")
 		}
-		return "", fmt.Errorf("failed to fetch latest version from tap: %v", err)
+		return "", fmt.Errorf("failed to fetch latest version: %v", err)
 	}
 
 	var info []boldBrewStatusInfo

--- a/site/templates/index.ejs
+++ b/site/templates/index.ejs
@@ -13,6 +13,7 @@
                     <img src="https://img.shields.io/github/actions/workflow/status/Valkyrie00/bold-brew/release.yml" alt="Build Status" width="100" height="20">
                     <img src="https://github.com/Valkyrie00/bold-brew/workflows/Security/badge.svg" alt="Security" width="100" height="20">
                     <img src="https://img.shields.io/github/downloads/Valkyrie00/bold-brew/total" alt="Downloads" width="100" height="20">
+                    <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fformulae.brew.sh%2Fapi%2Fformula%2Fbbrew.json&query=%24.analytics.install.30d.bbrew&label=homebrew%20installs%20%2830d%29&logo=homebrew&color=FBB040" alt="Homebrew Installs" width="160" height="20">
                     <img src="https://img.shields.io/badge/Featured_in-Project_Bluefin-0091e2" alt="Project Bluefin" width="140" height="20">
                     <img src="https://img.shields.io/badge/Featured_in-Aurora-5865f2" alt="Aurora" width="120" height="20">
                     <img src="https://img.shields.io/badge/Featured_in-Universal_Blue-1a73e8" alt="Universal Blue" width="145" height="20">


### PR DESCRIPTION
The self-update check previously queried the tap (valkyrie00/bbrew/bbrew), which could show a "New Version Available" notification even when the user installed from homebrew-core and couldn't actually upgrade yet. Now queries "bbrew" directly so it resolves to whichever source the user has.

Also adds a Homebrew installs (30d) badge to README and site, sourced from the formulae.brew.sh API via shields.io dynamic JSON badge.