### PR TITLE
fix: version check now resolves from user's install source

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -152,6 +152,7 @@
                     <img src="https://img.shields.io/github/actions/workflow/status/Valkyrie00/bold-brew/release.yml" alt="Build Status" width="100" height="20">
                     <img src="https://github.com/Valkyrie00/bold-brew/workflows/Security/badge.svg" alt="Security" width="100" height="20">
                     <img src="https://img.shields.io/github/downloads/Valkyrie00/bold-brew/total" alt="Downloads" width="100" height="20">
+                    <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fformulae.brew.sh%2Fapi%2Fformula%2Fbbrew.json&query=%24.analytics.install.30d.bbrew&label=homebrew%20installs%20%2830d%29&logo=homebrew&color=FBB040" alt="Homebrew Installs" width="160" height="20">
                     <img src="https://img.shields.io/badge/Featured_in-Project_Bluefin-0091e2" alt="Project Bluefin" width="140" height="20">
                     <img src="https://img.shields.io/badge/Featured_in-Aurora-5865f2" alt="Aurora" width="120" height="20">
                     <img src="https://img.shields.io/badge/Featured_in-Universal_Blue-1a73e8" alt="Universal Blue" width="145" height="20">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,25 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bold-brew.com/</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://bold-brew.com/blog/</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bold-brew.com/docs/</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bold-brew.com/changelog/</loc>
-    <lastmod>2026-07-05</lastmod>
+    <lastmod>2026-07-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
The self-update check previously queried the tap (valkyrie00/bbrew/bbrew), which could show a "New Version Available" notification even when the user installed from homebrew-core and couldn't actually upgrade yet. Now queries "bbrew" directly so it resolves to whichever source the user has.

Also adds a Homebrew installs (30d) badge to README and site, sourced from the formulae.brew.sh API via shields.io dynamic JSON badge.